### PR TITLE
Add ability to view all talent information(profile) #6

### DIFF
--- a/src/main/java/com/softserve/skillscope/config/SecurityConfiguration.java
+++ b/src/main/java/com/softserve/skillscope/config/SecurityConfiguration.java
@@ -51,7 +51,7 @@ public class SecurityConfiguration {
                 .requestMatchers(antMatcher("/h2/**")).permitAll() //works only for testing
                 .requestMatchers(antMatcher("/error")).permitAll()
                 .requestMatchers(HttpMethod.GET, "/talents").permitAll()
-                .requestMatchers(HttpMethod.GET, "/talents/{talent-id}").permitAll()
+                .requestMatchers(HttpMethod.GET, "/talents/{talent-id}").authenticated()
                 .requestMatchers(HttpMethod.POST, "/talents").permitAll()
                 .requestMatchers(HttpMethod.POST, "/talents/login").permitAll()
                 .anyRequest().authenticated());

--- a/src/main/java/com/softserve/skillscope/mapper/TalentMapper.java
+++ b/src/main/java/com/softserve/skillscope/mapper/TalentMapper.java
@@ -1,8 +1,10 @@
 package com.softserve.skillscope.mapper;
 
 import com.softserve.skillscope.talent.model.dto.GeneralTalent;
+import com.softserve.skillscope.talent.model.dto.TalentProfile;
 import com.softserve.skillscope.talent.model.entity.Talent;
 
 public interface TalentMapper {
     GeneralTalent toGeneralTalent(Talent talent);
+    TalentProfile toTalentProfile(Talent talent);
 }

--- a/src/main/java/com/softserve/skillscope/mapper/impl/TalentMapperImpl.java
+++ b/src/main/java/com/softserve/skillscope/mapper/impl/TalentMapperImpl.java
@@ -2,8 +2,12 @@ package com.softserve.skillscope.mapper.impl;
 
 import com.softserve.skillscope.mapper.TalentMapper;
 import com.softserve.skillscope.talent.model.dto.GeneralTalent;
+import com.softserve.skillscope.talent.model.dto.TalentProfile;
 import com.softserve.skillscope.talent.model.entity.Talent;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.Period;
 
 @Component
 public class TalentMapperImpl implements TalentMapper {
@@ -18,4 +22,22 @@ public class TalentMapperImpl implements TalentMapper {
                 .experience(talent.getTalentInfo().getExperience())
                 .build();
     }
+
+    @Override
+    public TalentProfile toTalentProfile(Talent talent) {
+        return TalentProfile.builder()
+                .id(talent.getId())
+                .image(talent.getTalentInfo().getImage())
+                .name(talent.getName())
+                .surname(talent.getSurname())
+                .experience(talent.getTalentInfo().getExperience())
+                .location(talent.getTalentInfo().getLocation())
+                .about(talent.getTalentInfo().getAbout())
+                .education(talent.getTalentInfo().getEducation())
+                .age(Period.between(talent.getTalentInfo().getAge(), LocalDate.now()).getYears())
+                .email(talent.getEmail())
+                .phone(talent.getTalentInfo().getPhone())
+                .build();
+    }
+
 }

--- a/src/main/java/com/softserve/skillscope/talent/controller/TalentController.java
+++ b/src/main/java/com/softserve/skillscope/talent/controller/TalentController.java
@@ -1,13 +1,11 @@
 package com.softserve.skillscope.talent;
 
+import com.softserve.skillscope.talent.model.dto.TalentProfile;
 import com.softserve.skillscope.talent.model.response.GeneralTalentResponse;
 import com.softserve.skillscope.talent.service.TalentService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -20,5 +18,11 @@ public class TalentController {
     @ResponseStatus(HttpStatus.OK)
     public GeneralTalentResponse showAllTalents(@RequestParam(defaultValue = "1") int page) {
         return talentService.getAllTalentsByPage(page);
+    }
+
+    @GetMapping("/talents/{talent-id}")
+    @ResponseStatus(HttpStatus.OK)
+    public TalentProfile showTalentProfile(@PathVariable("talent-id") Long talentId) {
+        return talentService.getTalentProfile(talentId);
     }
 }

--- a/src/main/java/com/softserve/skillscope/talent/model/dto/TalentProfile.java
+++ b/src/main/java/com/softserve/skillscope/talent/model/dto/TalentProfile.java
@@ -1,0 +1,20 @@
+package com.softserve.skillscope.talent.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record TalentProfile(
+        @NotBlank Long id,
+        @NotBlank String image,
+        @NotBlank String name,
+        @NotBlank String surname,
+        @NotBlank String experience,
+        @NotBlank String location,
+        @NotBlank String about,
+        @NotBlank String education,
+        @NotBlank int age,
+        @NotBlank String email,
+        @NotBlank String phone
+) {
+}

--- a/src/main/java/com/softserve/skillscope/talent/service/TalentService.java
+++ b/src/main/java/com/softserve/skillscope/talent/service/TalentService.java
@@ -1,7 +1,10 @@
 package com.softserve.skillscope.talent.service;
 
+import com.softserve.skillscope.talent.model.dto.TalentProfile;
 import com.softserve.skillscope.talent.model.response.GeneralTalentResponse;
 
 public interface TalentService {
     GeneralTalentResponse getAllTalentsByPage(int page);
+
+    TalentProfile getTalentProfile(Long talentId);
 }

--- a/src/main/java/com/softserve/skillscope/talent/service/TalentServiceImpl.java
+++ b/src/main/java/com/softserve/skillscope/talent/service/TalentServiceImpl.java
@@ -1,9 +1,11 @@
 package com.softserve.skillscope.talent.service;
 
 import com.softserve.skillscope.exception.generalException.BadRequestException;
+import com.softserve.skillscope.exception.talentException.TalentNotFoundException;
 import com.softserve.skillscope.mapper.TalentMapper;
 import com.softserve.skillscope.talent.TalentRepository;
 import com.softserve.skillscope.talent.model.dto.GeneralTalent;
+import com.softserve.skillscope.talent.model.dto.TalentProfile;
 import com.softserve.skillscope.talent.model.entity.Talent;
 import com.softserve.skillscope.talent.model.entity.TalentProperties;
 import com.softserve.skillscope.talent.model.response.GeneralTalentResponse;
@@ -47,5 +49,10 @@ public class TalentServiceImpl implements TalentService {
         } catch (Exception e) {
             throw new BadRequestException(e.getMessage());
         }
+    }
+
+    @Override
+    public TalentProfile getTalentProfile(Long talentId) {
+        return talentMapper.toTalentProfile(talentRepo.findById(talentId).orElseThrow(TalentNotFoundException::new));
     }
 }


### PR DESCRIPTION
Task for user story: [#2](https://github.com/Vladyslav-Team/frontend/issues/14)

Created a new method in the service and wrote the business logic to process the talent profile

Created a new endpoint @GetMapping("/talents/{talent-id}")

As a result, we get extended information about Talent in JSON format