### PR TITLE
3.1 Add ability to display Kudos on Proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Project SkillScope
 This is backend part of educational SkillScope project that will help you build website. Instruction describes how to clone and run the project on your local machine. 
 
-Current project version: `2.1.0`.
 ## Getting Started
 These instructions will help you get a copy of the project and running it on your local machine for development and testing purposes.
 

--- a/src/main/java/com/softserve/skillscope/proof/controller/ProofController.java
+++ b/src/main/java/com/softserve/skillscope/proof/controller/ProofController.java
@@ -4,6 +4,7 @@ import com.softserve.skillscope.generalModel.GeneralResponse;
 import com.softserve.skillscope.proof.model.request.ProofRequest;
 import com.softserve.skillscope.proof.model.dto.FullProof;
 import com.softserve.skillscope.proof.model.response.GeneralProofResponse;
+import com.softserve.skillscope.proof.model.response.KudosResponse;
 import com.softserve.skillscope.proof.service.ProofService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -51,8 +52,8 @@ public class ProofController {
 
     @PatchMapping("/talents/{talent-id}/proofs/{proof-id}")
     ResponseEntity<GeneralResponse> editProofById(@PathVariable("talent-id") Long talentId,
-                                              @PathVariable("proof-id") Long proofId,
-                                              @RequestBody ProofRequest proofToUpdate){
+                                                  @PathVariable("proof-id") Long proofId,
+                                                  @RequestBody ProofRequest proofToUpdate){
         return ResponseEntity.status(HttpStatus.OK).body(proofService.editProofById(talentId, proofId, proofToUpdate));
     }
 
@@ -67,6 +68,11 @@ public class ProofController {
     public ResponseEntity<GeneralResponse> hideProofById(@PathVariable("talent-id") Long talentId,
                                                          @PathVariable("proof-id") Long proofId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(proofService.hideProofById(talentId, proofId));
+    }
+
+    @GetMapping("/proofs/{proof-id}/kudos")
+    public ResponseEntity<KudosResponse> showAmountKudosOfProof(@PathVariable("proof-id") Long proofId){
+        return ResponseEntity.status(HttpStatus.OK).body(proofService.showAmountKudosOfProof(proofId));
     }
 
     @PostMapping("/proofs/{proof-id}/kudos")

--- a/src/main/java/com/softserve/skillscope/proof/model/dto/FullProof.java
+++ b/src/main/java/com/softserve/skillscope/proof/model/dto/FullProof.java
@@ -12,7 +12,7 @@ public record FullProof(
         Long talentId,
         String talentName,
         String talentSurname,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "hh:mm dd-MM-yyyy")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm dd-MM-yyyy")
         LocalDateTime publicationDate,
         String title,
         String description,

--- a/src/main/java/com/softserve/skillscope/proof/model/dto/GeneralProof.java
+++ b/src/main/java/com/softserve/skillscope/proof/model/dto/GeneralProof.java
@@ -10,10 +10,11 @@ import java.time.LocalDateTime;
 @Builder
 public record GeneralProof(
         @NotBlank Long id,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "hh:mm dd-MM-yyyy")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm dd-MM-yyyy")
         LocalDateTime publicationDate,
         String title,
         String description,
         @NotBlank ProofStatus status
+        //Integer kudos
 ) {
 }

--- a/src/main/java/com/softserve/skillscope/proof/model/entity/Proof.java
+++ b/src/main/java/com/softserve/skillscope/proof/model/entity/Proof.java
@@ -5,7 +5,6 @@ import com.softserve.skillscope.kudos.model.enity.Kudos;
 import com.softserve.skillscope.proof.model.response.ProofStatus;
 import com.softserve.skillscope.talent.model.entity.Talent;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -32,7 +31,7 @@ public class Proof {
     private Talent talent;
 
     @Column(name = "publication_date")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "hh:mm dd-MM-yyyy")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm dd-MM-yyyy")
     private LocalDateTime publicationDate;
 
     @Size(max = 100)

--- a/src/main/java/com/softserve/skillscope/proof/model/response/KudosResponse.java
+++ b/src/main/java/com/softserve/skillscope/proof/model/response/KudosResponse.java
@@ -1,0 +1,4 @@
+package com.softserve.skillscope.proof.model.response;
+
+public record KudosResponse(Long proofId, Integer amountOfKudos) {
+}

--- a/src/main/java/com/softserve/skillscope/proof/service/ProofService.java
+++ b/src/main/java/com/softserve/skillscope/proof/service/ProofService.java
@@ -4,20 +4,19 @@ import com.softserve.skillscope.generalModel.GeneralResponse;
 import com.softserve.skillscope.proof.model.dto.FullProof;
 import com.softserve.skillscope.proof.model.request.ProofRequest;
 import com.softserve.skillscope.proof.model.response.GeneralProofResponse;
+import com.softserve.skillscope.proof.model.response.KudosResponse;
 
 import java.util.Optional;
 
 
 public interface ProofService {
     FullProof getFullProof(Long proofId);
-
     GeneralProofResponse getAllProofByPage(Optional<Long> talentIdWrapper, int page, boolean newest);
     GeneralResponse addProof(Long talentId, ProofRequest creationRequest);
     GeneralResponse deleteProofById(Long talentId, Long proofId);
     GeneralResponse editProofById(Long talentId, Long proofId, ProofRequest proofToUpdate);
     GeneralResponse publishProofById(Long talentId, Long proofId);
-
     GeneralResponse hideProofById(Long talentId, Long proofId);
-
     GeneralResponse addKudosToProofByTalent(Long proofId);
+    KudosResponse showAmountKudosOfProof(Long proofId);
 }

--- a/src/main/java/com/softserve/skillscope/proof/service/ProofServiceImpl.java
+++ b/src/main/java/com/softserve/skillscope/proof/service/ProofServiceImpl.java
@@ -18,6 +18,7 @@ import com.softserve.skillscope.proof.model.entity.Proof;
 import com.softserve.skillscope.proof.model.entity.ProofProperties;
 import com.softserve.skillscope.proof.model.request.ProofRequest;
 import com.softserve.skillscope.proof.model.response.GeneralProofResponse;
+import com.softserve.skillscope.proof.model.response.KudosResponse;
 import com.softserve.skillscope.proof.model.response.ProofStatus;
 import com.softserve.skillscope.talent.TalentRepository;
 import com.softserve.skillscope.talent.model.entity.Talent;
@@ -179,6 +180,12 @@ public class ProofServiceImpl implements ProofService {
         }
         proofRepo.save(proof);
         return new GeneralResponse(proofId, "Proof successfully hidden!");
+    }
+
+    @Override
+    public KudosResponse showAmountKudosOfProof(Long proofId){
+        Proof proof = findProofById(proofId);
+        return new KudosResponse(proofId, proof.getKudos().size());
     }
 
     private void checkForChanges(ProofRequest proofToUpdate, Proof proof) {


### PR DESCRIPTION
TODO
The number of the Kudos is displayed on proof.
Talent can’t add Kudos to their own Proofs.
Kudos is general info, hence Kudos quantity is visible to everyone.